### PR TITLE
Set a timeout on get full dictionary  method GET CHANGES HTTP calls

### DIFF
--- a/CONTACT__examples/get_full_dictionary__method_GET_CHANGES.py
+++ b/CONTACT__examples/get_full_dictionary__method_GET_CHANGES.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     />
     """
 
-    rs = requests.post(URL_NG_SERVER, data=post_data)
+    rs = requests.post(URL_NG_SERVER, data=post_data, timeout=10.0)
     print(rs)
     print(len(rs.text))
 

--- a/Decorators__examples/requests__append_attempts.py
+++ b/Decorators__examples/requests__append_attempts.py
@@ -45,7 +45,7 @@ def attempts(
     ignored_exceptions=(RequestException,),
 )
 def do_get(url: str, *args, **kwargs) -> requests.Response:
-    rs = requests.get(url, *args, **kwargs)
+    rs = requests.get(url, *args, **kwargs, timeout=10.0)
     rs.raise_for_status()
 
     return rs

--- a/Moodle_examples/get_token.py
+++ b/Moodle_examples/get_token.py
@@ -14,7 +14,7 @@ def get_token(username, password):
         "service": "moodle_mobile_app",
     }
 
-    rs = requests.get("http://newlms.magtu.ru/login/token.php", params=params)
+    rs = requests.get("http://newlms.magtu.ru/login/token.php", params=params, timeout=10.0)
     print(rs)
 
     json_data = rs.json()

--- a/Moodle_examples/search_current_user.py
+++ b/Moodle_examples/search_current_user.py
@@ -23,7 +23,7 @@ params = {
     "values[0]": USERNAME,
 }
 
-rs = requests.get("http://newlms.magtu.ru/webservice/rest/server.php", params=params)
+rs = requests.get("http://newlms.magtu.ru/webservice/rest/server.php", params=params, timeout=10.0)
 print(rs)
 
 json_data = rs.json()

--- a/QuickChart__examples/draw_chart_on_other_image/main.py
+++ b/QuickChart__examples/draw_chart_on_other_image/main.py
@@ -32,7 +32,7 @@ img.save("input_with_chart_v1.png")
 
 # Variant 2
 url = qc.get_url()
-raw = requests.get(url, stream=True).raw
+raw = requests.get(url, stream=True, timeout=10.0).raw
 img_chart = Image.open(raw)
 
 img = Image.open("input.jpg")

--- a/alpha2_to_country/main.py
+++ b/alpha2_to_country/main.py
@@ -27,7 +27,7 @@ def init() -> None:
         )
         return
 
-    rs = requests.get("https://ru.wikipedia.org/wiki/ISO_3166-1")
+    rs = requests.get("https://ru.wikipedia.org/wiki/ISO_3166-1", timeout=10.0)
     root = BeautifulSoup(rs.content, "html.parser")
 
     ALPHA2_TO_COUNTRY = dict()

--- a/calc_statistic_anime_Naruto__by_fillers/main.py
+++ b/calc_statistic_anime_Naruto__by_fillers/main.py
@@ -23,7 +23,7 @@ def get_html_by_url__from_cache(url, cache_dir="cache"):
             return f.read()
 
     with open(file_name, "wb") as f:
-        rs = requests.get(url)
+        rs = requests.get(url, timeout=10.0)
         f.write(rs.content)
 
         return rs.content

--- a/cbr_ru/xml_metall/main_old.py
+++ b/cbr_ru/xml_metall/main_old.py
@@ -62,7 +62,7 @@ if __name__ == "__main__":
         url = f"http://www.cbr.ru/scripts/xml_metall.asp?date_req1={date_req1}&date_req2={date_req2}"
 
         with open(file_name, "w") as f:
-            rs = requests.get(url)
+            rs = requests.get(url, timeout=10.0)
             f.write(rs.text)
 
     with open(file_name, "rb") as f:

--- a/collector_bash_im/collector_bash_im.py
+++ b/collector_bash_im/collector_bash_im.py
@@ -93,7 +93,7 @@ query = session.query(Quote)
 
 
 if __name__ == "__main__":
-    rs = requests.get("http://bash.im")
+    rs = requests.get("http://bash.im", timeout=10.0)
     soup = BeautifulSoup(rs.content, "lxml")
     # print(soup)
     i = 0

--- a/concurrency_in_python__threading_processing/multiprocessing__examples/multiprocessing_with_webservers__flask.py
+++ b/concurrency_in_python__threading_processing/multiprocessing__examples/multiprocessing_with_webservers__flask.py
@@ -28,7 +28,7 @@ def go_parser(urls) -> None:
     while True:
         for url in urls:
             try:
-                rs = requests.get(url)
+                rs = requests.get(url, timeout=10.0)
                 print(f'Parser: {rs}. "{rs.text}"')
 
             except:

--- a/concurrency_in_python__threading_processing/multithreading__threading__examples/flask__threaded/flask_test_script.py
+++ b/concurrency_in_python__threading_processing/multithreading__threading__examples/flask__threaded/flask_test_script.py
@@ -8,12 +8,12 @@ import requests
 
 # With threaded
 for _ in range(5):
-    rs = requests.get("http://127.0.0.1:6000/")
+    rs = requests.get("http://127.0.0.1:6000/", timeout=10.0)
     print(rs.text)
 
 print()
 
 # Without threaded
 for _ in range(5):
-    rs = requests.get("http://127.0.0.1:6001/")
+    rs = requests.get("http://127.0.0.1:6001/", timeout=10.0)
     print(rs.text)

--- a/concurrency_in_python__threading_processing/multithreading__threading__examples/sync_vs_async__with_requests_and_bs4.py
+++ b/concurrency_in_python__threading_processing/multithreading__threading__examples/sync_vs_async__with_requests_and_bs4.py
@@ -12,7 +12,7 @@ import requests
 
 
 def go(url):
-    rs = requests.get(url)
+    rs = requests.get(url, timeout=10.0)
     root = BeautifulSoup(rs.content, "html.parser")
     return root.select_one(".user-details > a").text.strip()
 

--- a/design_patterns__examples/Proxy/example__cached.py
+++ b/design_patterns__examples/Proxy/example__cached.py
@@ -27,10 +27,10 @@ class GoUrl(IGoUrl):
     """Реальный субъект"""
 
     def get(self, url: str) -> requests.Response:
-        return requests.get(url)
+        return requests.get(url, timeout=10.0)
 
     def get_status_code(self, url: str) -> int:
-        return requests.head(url).status_code
+        return requests.head(url, timeout=10.0).status_code
 
 
 class GoUrlCachedProxy(IGoUrl):

--- a/disabling_redirection/requests_example.py
+++ b/disabling_redirection/requests_example.py
@@ -7,10 +7,10 @@ __author__ = "ipetrash"
 import requests
 
 
-rs = requests.get("http://ya.ru/")
+rs = requests.get("http://ya.ru/", timeout=10.0)
 print(rs.status_code, rs.url)
 # 200 https://ya.ru/
 
-rs = requests.get("http://ya.ru/", allow_redirects=False)
+rs = requests.get("http://ya.ru/", allow_redirects=False, timeout=10.0)
 print(rs.status_code, rs.url)
 # 302 http://ya.ru/

--- a/download_file/download_file.py
+++ b/download_file/download_file.py
@@ -41,7 +41,7 @@ def way2(url: str, file_name: str) -> None:
 
 @timer
 def way3(url: str, file_name: str) -> None:
-    p = requests.get(url)
+    p = requests.get(url, timeout=10.0)
     with open(file_name, "wb") as f:
         f.write(p.content)
 

--- a/download_file_with_progressbar/download_in_file__using_tqdm.py
+++ b/download_file_with_progressbar/download_in_file__using_tqdm.py
@@ -19,7 +19,7 @@ from humanize import naturalsize as sizeof_fmt
 
 url = "https://github.com/gil9red/NotesManager/raw/master/bin.rar"
 # Streaming, so we can iterate over the response.
-rs = requests.get(url, stream=True)
+rs = requests.get(url, stream=True, timeout=10.0)
 
 # Total size in bytes.
 total_size = int(rs.headers.get("content-length", 0))

--- a/download_file_with_progressbar/download_in_memory__using_tqdm.py
+++ b/download_file_with_progressbar/download_in_memory__using_tqdm.py
@@ -19,7 +19,7 @@ from humanize import naturalsize as sizeof_fmt
 
 url = "https://github.com/gil9red/NotesManager/raw/master/bin.rar"
 # Streaming, so we can iterate over the response.
-rs = requests.get(url, stream=True)
+rs = requests.get(url, stream=True, timeout=10.0)
 
 # Total size in bytes.
 total_size = int(rs.headers.get("content-length", 0))

--- a/download_volume_readmanga.py
+++ b/download_volume_readmanga.py
@@ -20,7 +20,7 @@ PATTERN = re.compile(r"\.init\(.*(\[\[.+\]\]).*\)")
 def get_url_images(url):
     print("Start get_url_images with url:", url)
 
-    rs = requests.get(url)
+    rs = requests.get(url, timeout=10.0)
 
     match = PATTERN.search(rs.text)
     if not match:

--- a/exchange_rates/banki_ru.py
+++ b/exchange_rates/banki_ru.py
@@ -27,6 +27,7 @@ def exchange_rate(currency_id, timestamp=None):
         "http://www.banki.ru/products/currency/ajax/quotations/value/cbr/",
         json=data,
         headers=headers,
+        timeout=10.0,
     )
     return rs.json()["value"]
 

--- a/exchange_rates/yahoo.py
+++ b/exchange_rates/yahoo.py
@@ -12,7 +12,7 @@ import requests
 
 # TODO: непонятно за какую дату находит
 url = "https://query.yahooapis.com/v1/public/yql?q=select+*+from+yahoo.finance.xchange+where+pair+=+%22USDRUB,EURRUB%22&format=json&env=store%3A%2F%2Fdatatables.org%2Falltableswithkeys&callback="
-rs = requests.get(url)
+rs = requests.get(url, timeout=10.0)
 
 text = "Курс:"
 for rate in rs.json()["query"]["results"]["rate"]:

--- a/extract_from_doc.qt.io/main.py
+++ b/extract_from_doc.qt.io/main.py
@@ -14,7 +14,7 @@ from bs4 import BeautifulSoup
 
 
 def get_path_and_content(url: str) -> tuple[str, str]:
-    rs = requests.get(url)
+    rs = requests.get(url, timeout=10.0)
     root = BeautifulSoup(rs.content, "lxml")
 
     path = root.select_one(".subtitle").text.strip()
@@ -28,7 +28,7 @@ def get_content(url: str) -> str:
 
 
 def get_list_urls_files(url: str) -> list[tuple[str, str]]:
-    rs = requests.get(url)
+    rs = requests.get(url, timeout=10.0)
     root = BeautifulSoup(rs.content, "lxml")
 
     urls_files_list = []

--- a/firefox/delete_tabs_and_bookmarks/delete_tabs_and_bookmarks_with_404.py
+++ b/firefox/delete_tabs_and_bookmarks/delete_tabs_and_bookmarks_with_404.py
@@ -29,7 +29,7 @@ def is_404(
 ) -> bool:
     while True:
         try:
-            rs = requests.get(url)
+            rs = requests.get(url, timeout=10.0)
             return rs.status_code == 404
         except Exception as e:
             log.error(f"Error {str(e)!r} on {url}")

--- a/flask__webservers/cookies/test.py
+++ b/flask__webservers/cookies/test.py
@@ -10,7 +10,7 @@ import requests
 session = requests.Session()
 
 
-rs = session.get("http://127.0.0.1:5001/get-cookies")
+rs = session.get("http://127.0.0.1:5001/get-cookies", timeout=10.0)
 print(rs, rs.url)
 print(rs.headers)
 print(rs.cookies)
@@ -24,7 +24,7 @@ print(rs.json())
 
 print()
 
-rs = session.post("http://127.0.0.1:5001/set-cookies", params=dict(a=123, b=3))
+rs = session.post("http://127.0.0.1:5001/set-cookies", params=dict(a=123, b=3), timeout=10.0)
 print(rs, rs.url)
 print(rs.headers)
 print(rs.cookies)
@@ -38,7 +38,7 @@ print(rs.json())
 
 print()
 
-rs = session.get("http://127.0.0.1:5001/get-cookies")
+rs = session.get("http://127.0.0.1:5001/get-cookies", timeout=10.0)
 print(rs, rs.url)
 print(rs.headers)
 print(rs.cookies)

--- a/flask__webservers/get_upload_and_image_process/main.py
+++ b/flask__webservers/get_upload_and_image_process/main.py
@@ -312,7 +312,7 @@ def upload_url():
         return redirect("/")
 
     url = request.form["url"]
-    file_data = requests.get(url).content
+    file_data = requests.get(url, timeout=10.0).content
 
     save_last_image(file_data)
 

--- a/flask__webservers/get_upload_image_info/main.py
+++ b/flask__webservers/get_upload_image_info/main.py
@@ -393,7 +393,7 @@ def get_info_from_url():
         return redirect("/")
 
     url = request.form["url"]
-    file_data = requests.get(url).content
+    file_data = requests.get(url, timeout=10.0).content
 
     info = get_image_info(file_data)
     info["img_base64"] = img_to_base64_html(file_data)

--- a/flask__webservers/server_with_additional_command_thread/main.py
+++ b/flask__webservers/server_with_additional_command_thread/main.py
@@ -49,7 +49,7 @@ def loop_command_function() -> None:
 
             url = "http://yandex.ru/images/search?text=" + COMMAND_TEXT
 
-            rs = requests.get(url)
+            rs = requests.get(url, timeout=10.0)
             print(rs)
 
             root = BeautifulSoup(rs.content, "lxml")

--- a/flask__webservers/show_last_bash_quotes/main.py
+++ b/flask__webservers/show_last_bash_quotes/main.py
@@ -29,7 +29,7 @@ logging.basicConfig(level=logging.DEBUG)
 @app.route("/")
 def index():
     try:
-        rs = requests.get("http://bash.im")
+        rs = requests.get("http://bash.im", timeout=10.0)
         soup = BeautifulSoup(rs.text, "lxml")
 
         number = today_quotes(soup)

--- a/flask__webservers/simple_upload_server/test.py
+++ b/flask__webservers/simple_upload_server/test.py
@@ -8,5 +8,5 @@ __author__ = "ipetrash"
 import requests
 
 
-rs = requests.post("http://localhost:6000", files={"file": open("disk_info.txt", "rb")})
+rs = requests.post("http://localhost:6000", files={"file": open("disk_info.txt", "rb")}, timeout=10.0)
 print(rs)

--- a/flask_restful__examples/todo/example.py
+++ b/flask_restful__examples/todo/example.py
@@ -12,7 +12,7 @@ URL_BASE = "http://127.0.0.1:5000"
 
 url = URL_BASE
 print(f"GET: {url}")
-rs = requests.get(url)
+rs = requests.get(url, timeout=10.0)
 print(rs, rs.json())
 """
 GET: http://127.0.0.1:5000
@@ -23,7 +23,7 @@ print()
 
 url = f"{URL_BASE}/todos"
 print(f"GET: {url}")
-rs = requests.get(url)
+rs = requests.get(url, timeout=10.0)
 rs_json = rs.json()
 print(rs, rs_json)
 """
@@ -37,7 +37,7 @@ todo_id = list(rs_json)[0]
 
 url = f"{URL_BASE}/todos/{todo_id}"
 print(f"GET: {url}")
-rs = requests.get(url)
+rs = requests.get(url, timeout=10.0)
 print(rs, rs.json())
 """
 GET: http://127.0.0.1:5000/todos/todo1
@@ -48,7 +48,7 @@ print()
 
 url = f"{URL_BASE}/todos/{todo_id}"
 print(f"PUT: {url}")
-rs = requests.put(url, json=dict(task=f"Update task {todo_id}"))
+rs = requests.put(url, json=dict(task=f"Update task {todo_id}"), timeout=10.0)
 print(rs, rs.json())
 """
 PUT: http://127.0.0.1:5000/todos/todo1
@@ -59,7 +59,7 @@ print()
 
 url = f"{URL_BASE}/todos/{todo_id}_new"
 print(f"PUT: {url}")
-rs = requests.put(url, json=dict(task=f"New task!"))
+rs = requests.put(url, json=dict(task=f"New task!"), timeout=10.0)
 print(rs, rs.json())
 """
 PUT: http://127.0.0.1:5000/todos/todo1_new
@@ -70,7 +70,7 @@ print()
 
 url = f"{URL_BASE}/todos"
 print(f"POST: {url}")
-rs = requests.post(url, json=dict(task=f"New task!"))
+rs = requests.post(url, json=dict(task=f"New task!"), timeout=10.0)
 print(rs, rs.json())
 """
 POST: http://127.0.0.1:5000/todos
@@ -81,7 +81,7 @@ print()
 
 url = f"{URL_BASE}/todos"
 print(f"GET: {url}")
-rs = requests.get(url)
+rs = requests.get(url, timeout=10.0)
 print(rs, rs.json())
 """
 GET: http://127.0.0.1:5000/todos
@@ -92,7 +92,7 @@ print()
 
 url = f"{URL_BASE}/todos/{todo_id}"
 print(f"DELETE: {url}")
-rs = requests.delete(url)
+rs = requests.delete(url, timeout=10.0)
 print(rs, rs.json())
 """
 DELETE: http://127.0.0.1:5000/todos/todo1
@@ -103,7 +103,7 @@ print()
 
 url = f"{URL_BASE}/todos"
 print(f"GET: {url}")
-rs = requests.get(url)
+rs = requests.get(url, timeout=10.0)
 print(rs, rs.json())
 """
 GET: http://127.0.0.1:5000/todos
@@ -114,7 +114,7 @@ print()
 
 url = URL_BASE
 print(f"GET: {url}")
-rs = requests.get(url)
+rs = requests.get(url, timeout=10.0)
 print(rs, rs.json())
 """
 GET: http://127.0.0.1:5000

--- a/for_games/Binding of Isaac Rebirth/print_number_of_items.py
+++ b/for_games/Binding of Isaac Rebirth/print_number_of_items.py
@@ -16,7 +16,7 @@ session.headers[
 ] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0"
 
 
-rs = session.get("https://isaac-items.ru/")
+rs = session.get("https://isaac-items.ru/", timeout=10.0)
 rs.raise_for_status()
 
 game_by_number: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))

--- a/for_games/Bloodborne/bloodborne_fandom_com__ru__wiki__Боссы/main.py
+++ b/for_games/Bloodborne/bloodborne_fandom_com__ru__wiki__Боссы/main.py
@@ -25,7 +25,7 @@ URL: str = "https://bloodborne.fandom.com/ru/wiki/Боссы"
 
 
 def get_bosses() -> dict[str, list[Boss]]:
-    rs = requests.get(URL)
+    rs = requests.get(URL, timeout=10.0)
     rs.raise_for_status()
 
     soup = BeautifulSoup(rs.content, "html.parser")

--- a/for_games/Bloodborne/bloodborne_fandom_com__ru__wiki__Категория_Локации/main.py
+++ b/for_games/Bloodborne/bloodborne_fandom_com__ru__wiki__Категория_Локации/main.py
@@ -46,7 +46,7 @@ class Location:
 links: set[tuple[str, str]] = set()
 location_by_url: dict[str, str] = dict()
 
-rs = requests.get(URL)
+rs = requests.get(URL, timeout=10.0)
 rs.raise_for_status()
 
 soup = BeautifulSoup(rs.content, "html.parser")
@@ -60,7 +60,7 @@ for location in locations:
     for _ in range(3):
         try:
             # TODO: Оптимизации не хватает
-            rs = requests.get(location.url)
+            rs = requests.get(location.url, timeout=10.0)
             rs.raise_for_status()
         except Exception as e:
             print(f"Error: {e}, url: {location.url}")

--- a/for_games/Dark Souls/bonfires.py
+++ b/for_games/Dark Souls/bonfires.py
@@ -8,7 +8,7 @@ import requests
 from bs4 import BeautifulSoup
 
 
-rs = requests.get("https://darksouls.fandom.com/ru/wiki/Костер")
+rs = requests.get("https://darksouls.fandom.com/ru/wiki/Костер", timeout=10.0)
 root = BeautifulSoup(rs.content, "html.parser")
 
 for h2 in root.select("h2"):

--- a/for_games/Dark Souls/common.py
+++ b/for_games/Dark Souls/common.py
@@ -72,7 +72,7 @@ class Parser:
 
         """
 
-        rs = requests.get(url_location)
+        rs = requests.get(url_location, timeout=10.0)
         root = BeautifulSoup(rs.content, "html.parser")
 
         table_locations = None
@@ -103,7 +103,7 @@ class Parser:
 
         """
 
-        rs = requests.get(url_location)
+        rs = requests.get(url_location, timeout=10.0)
         root = BeautifulSoup(rs.content, "html.parser")
 
         table_bosses = None
@@ -132,7 +132,7 @@ class Parser:
         links = set()
         link_boss = set()
 
-        rs = requests.get(self._url_locations)
+        rs = requests.get(self._url_locations, timeout=10.0)
         root = BeautifulSoup(rs.content, "html.parser")
 
         for a in root.select(".category-page__member-link"):

--- a/for_games/Dark Souls/print__stats/common.py
+++ b/for_games/Dark Souls/print__stats/common.py
@@ -9,7 +9,7 @@ from bs4 import BeautifulSoup
 
 
 def get_parsed_two_column_table_stats(url: str) -> list[tuple[str, str]]:
-    rs = requests.get(url)
+    rs = requests.get(url, timeout=10.0)
     root = BeautifulSoup(rs.content, "html.parser")
 
     table = root.select_one("table")

--- a/for_games/Dark Souls/print_timeline_of_release_years/main.py
+++ b/for_games/Dark Souls/print_timeline_of_release_years/main.py
@@ -13,7 +13,7 @@ from bs4 import BeautifulSoup
 
 
 def get_parsed_two_column_wikitable(url: str) -> [(str, str)]:
-    rs = requests.get(url)
+    rs = requests.get(url, timeout=10.0)
     root = BeautifulSoup(rs.content, "html.parser")
 
     table = root.select_one(".wikitable")

--- a/for_games/Dark Souls/ru_darksouls_wikia_com__fandom__bosses/utils.py
+++ b/for_games/Dark Souls/ru_darksouls_wikia_com__fandom__bosses/utils.py
@@ -47,7 +47,7 @@ class Boss(NamedTuple):
 
 
 def parse(url: str) -> Tuple[requests.Response, BeautifulSoup]:
-    rs = session.get(url)
+    rs = session.get(url, timeout=10.0)
     return rs, BeautifulSoup(rs.content, "html.parser")
 
 

--- a/for_games/Demons Souls/demonssouls_fandom_com__ru__wiki__Боссы/main.py
+++ b/for_games/Demons Souls/demonssouls_fandom_com__ru__wiki__Боссы/main.py
@@ -21,7 +21,7 @@ class Boss(NamedTuple):
 
 
 def get_bosses(url: str) -> dict[str, list[Boss]]:
-    rs = requests.get(url)
+    rs = requests.get(url, timeout=10.0)
     root = BeautifulSoup(rs.content, "html.parser")
 
     bosses_by_category = defaultdict(list)

--- a/for_games/Demons Souls/demonssouls_fandom_com__ru__wiki__Классы.py
+++ b/for_games/Demons Souls/demonssouls_fandom_com__ru__wiki__Классы.py
@@ -11,7 +11,7 @@ import requests
 def get_class_by_stats() -> dict[str, dict[str, int]]:
     url = "https://demonssouls.fandom.com/ru/wiki/Классы"
 
-    rs = requests.get(url)
+    rs = requests.get(url, timeout=10.0)
     root = BeautifulSoup(rs.content, "html.parser")
 
     class_by_stats = dict()

--- a/for_games/Elden Ring/common.py
+++ b/for_games/Elden Ring/common.py
@@ -15,5 +15,5 @@ session.headers[
 
 
 def parse(url: str) -> tuple[requests.Response, BeautifulSoup]:
-    rs = session.get(url)
+    rs = session.get(url, timeout=10.0)
     return rs, BeautifulSoup(rs.content, "html.parser")


### PR DESCRIPTION
This fell out while I was looking at CONTACT__examples/get_full_dictionary__method_GET_CHANGES.py. Set a timeout on get full dictionary  method GET CHANGES HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.